### PR TITLE
Add optional outputMask 

### DIFF
--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -60,7 +60,7 @@ class DialPad extends StatefulWidget {
   final double subtitleTextSize;
 
   /// outputMask is the mask applied to the output text. Defaults to (000) 000-0000
-  final String outputMask;
+  final String? outputMask;
   final String hint;
 
   /// Whether to enable DTMF tones. Defaults to [false].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,11 @@ dependencies:
     sdk: flutter
 
 #  flutter_dtmf: ^2.0.2
-  flutter_masked_text2: ^0.9.1
+  # Since flutter_masked_text2 is no longer supported, we use a forked version until a package with fix becomes available or an alternative is implemented
+  flutter_masked_text2:
+    git:
+        url: https://github.com/cybex-dev/flutter_masked_text
+        ref: 156f63b77d23148d9f1544230e3201ab6172f470 # branch 'fix_null_mask'
   #auto_size_text: ^2.0.2+1
 
 dev_dependencies:


### PR DESCRIPTION

Update to allow custom dialpad inputs outside of the standard phone number scope.

**Please note:**

Since author no longer supports [this](https://github.com/djade007/flutter_masked_text#alert) repo, I've forked and added a specific commit to apply a null check fix.

This should be considered a temporary measure until a permanent fix, fork or package is provided.

See: [https://github.com/cybex-dev/flutter_masked_text/commit/156f63b77d23148d9f1544230e3201ab6172f470](https://github.com/cybex-dev/flutter_masked_text/commit/156f63b77d23148d9f1544230e3201ab6172f470)