### PR TITLE
Feat: Add clamping to UI scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Add `dialButton` & `backspaceButton` padding
 * Added default & button-specific `ScalingType` and `ScalingSize` options
 * Add content padding for dial, backspace and keypad buttons
+* Add customizing dial, backspace button color & sizes
+* Add scale clamping as a percentage of icon/text size for improved UI/UX
 
 ## [1.0.5] - 2023-02-08
 * Add ability to hide DialButton subtitle text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add `copyToClipboard` custom widget builder for `PhoneTextInput`
 * Add `dialButton` & `backspaceButton` padding
 * Added default & button-specific `ScalingType` and `ScalingSize` options
+* Add content padding for dial, backspace and keypad buttons
 
 ## [1.0.5] - 2023-02-08
 * Add ability to hide DialButton subtitle text

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Scaling Size provides an easy way to specify the scalar multiplier for the scali
 #### Scalable
 If you wish to add your own Scalable button, feel free to create a widget  `with Scalable` to make use of the `rescale` function.
 
+#### Clamping
+
+Scaled UI elements may become extremely small, using `minScalingSize` and `maxScalingSize` you can clamp the scaling to a percentage of the original size. This is useful for ensuring the UI is still usable.
+
 ## Screenshots  
   
 ![iOS Screenshot](screenshots/screenshot1.png?raw=true "iOS Screenshot") | ![Android Screenshot](screenshots/screenshot2.png?raw=true "Android Screenshot")  

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -110,6 +110,9 @@ class DialPad extends StatefulWidget {
   /// [ScalingType] for the dial button. Defaults to [ScalingSize.small].
   final ScalingSize? backspaceButtonScalingSize;
 
+  /// Add dial button icon size. Defaults to [75].
+  final double? dialButtonIconSize;
+
   /// Add dial button content padding. Defaults to [EdgeInsets.zero].
   final EdgeInsets? dialContentPadding;
 
@@ -153,6 +156,7 @@ class DialPad extends StatefulWidget {
     this.scalingSize = ScalingSize.medium,
     this.dialingButtonScalingSize,
     this.backspaceButtonScalingSize,
+    this.dialButtonIconSize,
     this.dialContentPadding,
     this.backspaceContentPadding,
     this.keyButtonContentPadding,
@@ -295,6 +299,7 @@ class _DialPadState extends State<DialPad> {
     final dialButton = widget.hideDialButton
         ? null
         : ActionButton(
+            iconSize: widget.dialButtonIconSize ?? 75,
             padding: widget.dialButtonPadding ?? widget.buttonPadding,
             buttonType: widget.buttonType,
             icon: widget.dialButtonIcon,

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -110,6 +110,15 @@ class DialPad extends StatefulWidget {
   /// [ScalingType] for the dial button. Defaults to [ScalingSize.small].
   final ScalingSize? backspaceButtonScalingSize;
 
+  /// Add dial button content padding. Defaults to [EdgeInsets.zero].
+  final EdgeInsets? dialContentPadding;
+
+  /// Add backspace button content padding. Defaults to [EdgeInsets.zero].
+  final EdgeInsets? backspaceContentPadding;
+
+  /// Add keypad button content padding used by [_defaultKeypadButtonBuilder]. Defaults to [EdgeInsets.zero].
+  final EdgeInsets? keyButtonContentPadding;
+
   DialPad({
     this.makeCall,
     this.keyPressed,
@@ -144,6 +153,9 @@ class DialPad extends StatefulWidget {
     this.scalingSize = ScalingSize.medium,
     this.dialingButtonScalingSize,
     this.backspaceButtonScalingSize,
+    this.dialContentPadding,
+    this.backspaceContentPadding,
+    this.keyButtonContentPadding,
   });
 
   /// Returns a [DialPad] with an iOS-style design (i.e. Apple).
@@ -263,6 +275,7 @@ class _DialPadState extends State<DialPad> {
       onTap: () => _onKeypadPressed(key),
       buttonType: widget.buttonType,
       padding: widget.buttonPadding,
+      contentPadding: widget.keyButtonContentPadding,
       textColor: widget.buttonTextColor,
       iconColor: widget.buttonTextColor,
       subtitleIconColor: widget.buttonTextColor,
@@ -290,6 +303,7 @@ class _DialPadState extends State<DialPad> {
             onTap: _onDialPressed,
             scalingType: widget.scalingType,
             scalingSize: widget.dialingButtonScalingSize ?? widget.scalingSize,
+            contentPadding: widget.dialContentPadding,
             // NOTE(cybex-dev) add as option in future
             // disabled: _value.isEmpty || widget.makeCall == null,
           );
@@ -308,6 +322,7 @@ class _DialPadState extends State<DialPad> {
             color: Colors.transparent,
             scalingType: widget.scalingType,
             scalingSize: widget.backspaceButtonScalingSize ?? widget.scalingSize,
+            contentPadding: widget.backspaceContentPadding,
           );
 
     /// Footer contains the dial and backspace buttons

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -83,6 +83,12 @@ class DialPad extends StatefulWidget {
   /// Padding around the button. Defaults to [buttonPadding].
   final EdgeInsets? backspaceButtonPadding;
 
+  /// Background color of the backspace button. Defaults to [buttonColor].
+  final Color? backspaceButtonColor;
+
+  /// Icon size of the backspace button. Defaults to [75].
+  final double? backspaceButtonIconSize;
+
   /// Padding around the button. Defaults to [buttonPadding].
   final EdgeInsets? dialButtonPadding;
 
@@ -156,6 +162,8 @@ class DialPad extends StatefulWidget {
     this.scalingSize = ScalingSize.medium,
     this.dialingButtonScalingSize,
     this.backspaceButtonScalingSize,
+    this.backspaceButtonColor,
+    this.backspaceButtonIconSize,
     this.dialButtonIconSize,
     this.dialContentPadding,
     this.backspaceContentPadding,
@@ -320,11 +328,11 @@ class _DialPadState extends State<DialPad> {
             onTap: _onBackspacePressed,
             // disabled: _value.isEmpty,
             buttonType: widget.buttonType,
-            iconSize: 75,
+            iconSize: widget.backspaceButtonIconSize ?? 75,
             iconColor: widget.backspaceButtonIconColor,
             padding: widget.backspaceButtonPadding ?? widget.buttonPadding,
             icon: Icons.backspace,
-            color: Colors.transparent,
+            color: widget.backspaceButtonColor ?? Colors.transparent,
             scalingType: widget.scalingType,
             scalingSize: widget.backspaceButtonScalingSize ?? widget.scalingSize,
             contentPadding: widget.backspaceContentPadding,

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -203,6 +203,7 @@ class DialPad extends StatefulWidget {
       buttonPadding: EdgeInsets.all(16),
       backspaceButtonPadding: EdgeInsets.all(24),
       dialButtonPadding: EdgeInsets.all(8),
+      maxScalingSize: 0.7,
     );
   }
 

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -376,6 +376,8 @@ class _DialPadState extends State<DialPad> {
           copyToClipboard: widget.copyToClipboard,
           readOnly: !widget.pasteFromClipboard,
           scalingType: widget.scalingType,
+          minScalingSize: widget.minScalingSize,
+          maxScalingSize: widget.maxScalingSize,
         ),
       ),
       Expanded(

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -116,6 +116,12 @@ class DialPad extends StatefulWidget {
   /// [ScalingType] for the dial button. Defaults to [ScalingSize.small].
   final ScalingSize? backspaceButtonScalingSize;
 
+  /// Clamp the scaling size to a maximum value, this limits the rescaling size as a percentage of the provided value e.g. font or text size.
+  final double? maxScalingSize;
+
+  /// Clamp the scaling size to a minimum value, this limits the rescaling size as a percentage of the provided value e.g. font or text size.
+  final double? minScalingSize;
+
   /// Add dial button icon size. Defaults to [75].
   final double? dialButtonIconSize;
 
@@ -164,6 +170,8 @@ class DialPad extends StatefulWidget {
     this.backspaceButtonScalingSize,
     this.backspaceButtonColor,
     this.backspaceButtonIconSize,
+    this.minScalingSize,
+    this.maxScalingSize,
     this.dialButtonIconSize,
     this.dialContentPadding,
     this.backspaceContentPadding,
@@ -296,6 +304,8 @@ class _DialPadState extends State<DialPad> {
       fontSize: widget.buttonTextSize,
       scalingType: widget.scalingType,
       scalingSize: widget.scalingSize,
+      minScalingSize: widget.minScalingSize,
+      maxScalingSize: widget.maxScalingSize,
     );
   }
 
@@ -317,6 +327,8 @@ class _DialPadState extends State<DialPad> {
             onTap: _onDialPressed,
             scalingType: widget.scalingType,
             scalingSize: widget.dialingButtonScalingSize ?? widget.scalingSize,
+            minScalingSize: widget.minScalingSize,
+            maxScalingSize: widget.maxScalingSize,
             contentPadding: widget.dialContentPadding,
             // NOTE(cybex-dev) add as option in future
             // disabled: _value.isEmpty || widget.makeCall == null,
@@ -336,6 +348,8 @@ class _DialPadState extends State<DialPad> {
             color: widget.backspaceButtonColor ?? Colors.transparent,
             scalingType: widget.scalingType,
             scalingSize: widget.backspaceButtonScalingSize ?? widget.scalingSize,
+            minScalingSize: widget.minScalingSize,
+            maxScalingSize: widget.maxScalingSize,
             contentPadding: widget.backspaceContentPadding,
           );
 

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -285,6 +285,7 @@ class _DialPadState extends State<DialPad> {
       color: widget.buttonColor,
       hideSubtitle: widget.hideSubtitle,
       onTap: () => _onKeypadPressed(key),
+      onLongPressed: () => _onKeypadPressed(altKey ?? key),
       buttonType: widget.buttonType,
       padding: widget.buttonPadding,
       contentPadding: widget.keyButtonContentPadding,

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -278,7 +278,7 @@ class _DialPadState extends State<DialPad> {
     }
   }
 
-  Widget _defaultDialButtonBuilder(BuildContext context, int index, KeyValue key, KeyValue? altKey, String? hint) {
+  Widget _defaultKeypadButtonBuilder(BuildContext context, int index, KeyValue key, KeyValue? altKey, String? hint) {
     return ActionButton(
       title: key.value,
       subtitle: altKey?.value ?? hint,
@@ -300,7 +300,7 @@ class _DialPadState extends State<DialPad> {
 
   @override
   Widget build(BuildContext context) {
-    final _keypadButtonBuilder = /*widget.keypadButtonBuilder ??  */ _defaultDialButtonBuilder;
+    final _keypadButtonBuilder = /*widget.keypadButtonBuilder ??  */ _defaultKeypadButtonBuilder;
     final _generator = widget.generator ?? IosKeypadGenerator();
 
     /// Dial button

--- a/lib/src/mixins/scalable.dart
+++ b/lib/src/mixins/scalable.dart
@@ -6,7 +6,12 @@ import '../widgets/scalable/scaling_type.dart';
 
 mixin Scalable {
   /// Rescale a value based on the [ScalingType] provided.
-  double rescale(Size screenSize, ScalingType scalingType, value, {ScalingSize scalingSize = ScalingSize.small}) {
+  double rescale(Size screenSize, ScalingType scalingType, double value, {ScalingSize scalingSize = ScalingSize.small, double? minClamp, double? maxClamp}) {
+    assert(value >= 0, "value must be greater than or equal to 0");
+    assert(minClamp == null || minClamp >= 0, "minClamp must be greater than or equal to 0");
+    assert(maxClamp == null || maxClamp >= 0, "maxClamp must be greater than or equal to 0");
+    assert(minClamp == null || maxClamp == null || minClamp <= maxClamp, "minClamp must be less than or equal to maxClamp");
+
     double scalar = scalingSize.scalar;
     double sizeFactor = 1.0;
 
@@ -26,6 +31,15 @@ mixin Scalable {
       case ScalingType.max:
         sizeFactor = max(screenSize.width, screenSize.height) * scalar;
         break;
+    }
+
+    // apply clamps
+    if (minClamp != null && sizeFactor < minClamp) {
+      print("[minClamp] adjusting sizeFactor from $sizeFactor to $minClamp");
+      sizeFactor = minClamp;
+    } else if (maxClamp != null && sizeFactor > maxClamp) {
+      print("[maxClamp] adjusting sizeFactor from $sizeFactor to $maxClamp");
+      sizeFactor = maxClamp;
     }
 
     return value * sizeFactor;

--- a/lib/src/widgets/buttons/action_button.dart
+++ b/lib/src/widgets/buttons/action_button.dart
@@ -35,6 +35,9 @@ class ActionButton extends StatelessWidget with Scalable {
   /// Callback when the button is tapped.
   final VoidCallback? onTap;
 
+  /// Callback when the button is held down for a longer period of time.
+  final VoidCallback? onLongPressed;
+
   /// Button display style (clipping). Defaults to [ButtonType.rectangle].
   /// [ButtonType.circle] will clip the button to a circle e.g. an iPhone keypad
   /// [ButtonType.rectangle] will clip the button to a rectangle e.g. an Android keypad
@@ -86,6 +89,7 @@ class ActionButton extends StatelessWidget with Scalable {
     this.iconColor = Colors.white,
     this.subtitleIconColor,
     this.onTap,
+    this.onLongPressed,
     this.buttonType = ButtonType.rectangle,
     this.padding = const EdgeInsets.all(0),
     this.fontSize = 75,
@@ -166,6 +170,7 @@ class ActionButton extends StatelessWidget with Scalable {
           child: child,
           onPressed: onTap != null ? onTap : null,
           padding: contentPadding ?? EdgeInsets.all(0),
+          onLongPressed: onLongPressed != null ? onLongPressed : null,
         ),
       );
     });

--- a/lib/src/widgets/buttons/action_button.dart
+++ b/lib/src/widgets/buttons/action_button.dart
@@ -164,7 +164,7 @@ class ActionButton extends StatelessWidget with Scalable {
           buttonType: buttonType,
           disabled: disabled,
           child: child,
-          onTap: onTap != null ? onTap : null,
+          onPressed: onTap != null ? onTap : null,
           padding: contentPadding ?? EdgeInsets.all(0),
         ),
       );

--- a/lib/src/widgets/buttons/action_button.dart
+++ b/lib/src/widgets/buttons/action_button.dart
@@ -163,6 +163,7 @@ class ActionButton extends StatelessWidget with Scalable {
       final child = subtitleWidget == null || hideSubtitle == true
           ? titleWidget
           : Column(
+              mainAxisAlignment: MainAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
               children: [
                 titleWidget,

--- a/lib/src/widgets/buttons/action_button.dart
+++ b/lib/src/widgets/buttons/action_button.dart
@@ -75,6 +75,13 @@ class ActionButton extends StatelessWidget with Scalable {
   /// [ScalingSize] for the button. Defaults to [ScalingSize.small].
   final ScalingSize scalingSize;
 
+  /// Minimum scaling size for the button content. Defaults to null.
+  final double? minScalingSize;
+
+  /// Maximum scaling size for the button content. Defaults to null.
+  final double? maxScalingSize;
+
+  /// Padding around the button's content. Defaults to null.
   final EdgeInsets? contentPadding;
 
   ActionButton({
@@ -99,12 +106,14 @@ class ActionButton extends StatelessWidget with Scalable {
     this.disabled = false,
     this.scalingType = ScalingType.fixed,
     this.scalingSize = ScalingSize.small,
+    this.minScalingSize,
+    this.maxScalingSize,
     this.contentPadding,
   });
 
   /// Get title widget, prefer icon over title
   Widget _buildTitleWidget(Size screenSize) {
-    double size = rescale(screenSize, scalingType, icon != null ? iconSize : fontSize, scalingSize: scalingSize);
+    double size = rescale(screenSize, scalingType, icon != null ? iconSize : fontSize, scalingSize: scalingSize, minClamp: minScalingSize, maxClamp: maxScalingSize);
     Widget widget = icon != null
         ? Icon(icon, size: size, color: iconColor)
         : Text(
@@ -130,11 +139,11 @@ class ActionButton extends StatelessWidget with Scalable {
   /// Get subtitle widget, prefer subtitleIcon over subtitle
   Widget? _buildSubtitleWidget(Size screenSize) {
     return subtitleIcon != null
-        ? Icon(subtitleIcon, size: rescale(screenSize, scalingType, subtitleIconSize, scalingSize: scalingSize), color: subtitleIconColor ?? iconColor)
+        ? Icon(subtitleIcon, size: rescale(screenSize, scalingType, subtitleIconSize, scalingSize: scalingSize, minClamp: minScalingSize, maxClamp: maxScalingSize), color: subtitleIconColor ?? iconColor)
         : (subtitle != null)
             ? Text(
                 subtitle ?? "",
-                style: TextStyle(color: textColor, fontSize: rescale(screenSize, scalingType, subtitleFontSize, scalingSize: scalingSize)),
+                style: TextStyle(color: textColor, fontSize: rescale(screenSize, scalingType, subtitleFontSize, scalingSize: scalingSize, minClamp: minScalingSize, maxClamp: maxScalingSize)),
               )
             : null;
   }

--- a/lib/src/widgets/buttons/action_button.dart
+++ b/lib/src/widgets/buttons/action_button.dart
@@ -72,6 +72,8 @@ class ActionButton extends StatelessWidget with Scalable {
   /// [ScalingSize] for the button. Defaults to [ScalingSize.small].
   final ScalingSize scalingSize;
 
+  final EdgeInsets? contentPadding;
+
   ActionButton({
     this.key,
     this.title,
@@ -93,6 +95,7 @@ class ActionButton extends StatelessWidget with Scalable {
     this.disabled = false,
     this.scalingType = ScalingType.fixed,
     this.scalingSize = ScalingSize.small,
+    this.contentPadding,
   });
 
   /// Get title widget, prefer icon over title
@@ -162,7 +165,7 @@ class ActionButton extends StatelessWidget with Scalable {
           disabled: disabled,
           child: child,
           onTap: onTap != null ? onTap : null,
-          padding: EdgeInsets.zero,
+          padding: contentPadding ?? EdgeInsets.all(0),
         ),
       );
     });

--- a/lib/src/widgets/phone_text_field.dart
+++ b/lib/src/widgets/phone_text_field.dart
@@ -46,6 +46,12 @@ class PhoneTextField extends StatelessWidget with Scalable {
   /// [ScalingSize] for the button. Defaults to [ScalingSize.small].
   final ScalingSize scalingSize;
 
+  /// Minimum scaling size for the button content. Defaults to null.
+  final double? minScalingSize;
+
+  /// Maximum scaling size for the button content. Defaults to null.
+  final double? maxScalingSize;
+
   const PhoneTextField({
     super.key,
     this.textStyle,
@@ -61,6 +67,8 @@ class PhoneTextField extends StatelessWidget with Scalable {
     this.copyToClipboardBuilder,
     this.scalingType = ScalingType.fixed,
     this.scalingSize = ScalingSize.small,
+    this.minScalingSize,
+    this.maxScalingSize,
   });
 
   void _onCopyPressed() {
@@ -74,7 +82,7 @@ class PhoneTextField extends StatelessWidget with Scalable {
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
-    final size = rescale(screenSize, scalingType, textSize, scalingSize: scalingSize);
+    final size = rescale(screenSize, scalingType, textSize, scalingSize: scalingSize, minClamp: minScalingSize, maxClamp: maxScalingSize);
 
     final _builtTextStyle = TextStyle(
       color: textColor,

--- a/lib/src/widgets/scalable/scalable_button.dart
+++ b/lib/src/widgets/scalable/scalable_button.dart
@@ -42,20 +42,24 @@ class ScalableButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Use MaterialButton to get the Material ripple, splash and highlight colors including animations and gestures.
-    return MaterialButton(
-      color: createMaterialColor(color),
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        shape: buttonType == ButtonType.rectangle ? BoxShape.rectangle : BoxShape.circle,
+      ),
+      child: MaterialButton(
+        color: createMaterialColor(color),
         onPressed: disabled ? null : onPressed,
         onLongPress: disabled ? null : onLongPressed,
-      animationDuration: Duration(milliseconds: 300),
-      child: Center(
-        child: child,
+        animationDuration: Duration(milliseconds: 300),
+        child: Center(
+          child: child,
+        ),
+        padding: padding,
+        elevation: 0,
+        highlightElevation: 0,
+        hoverElevation: 0,
       ),
-      shape: buttonType == ButtonType.rectangle ? RoundedRectangleBorder(borderRadius: BorderRadius.zero) : CircleBorder(),
-      padding: padding,
-      elevation: 0,
-      highlightElevation: 0,
-      hoverElevation: 0,
-      clipBehavior: Clip.antiAliasWithSaveLayer,
     );
   }
 }

--- a/lib/src/widgets/scalable/scalable_button.dart
+++ b/lib/src/widgets/scalable/scalable_button.dart
@@ -11,6 +11,9 @@ class ScalableButton extends StatelessWidget {
   /// Callback when the button is tapped.
   final GestureTapCallback? onPressed;
 
+  /// Callback when the button is long pressed.
+  final GestureLongPressCallback? onLongPressed;
+
   /// Button display style (clipping). Defaults to [ButtonType.rectangle].
   /// [ButtonType.circle] will clip the button to a circle e.g. an iPhone keypad
   /// [ButtonType.rectangle] will clip the button to a rectangle e.g. an Android keypad
@@ -29,6 +32,7 @@ class ScalableButton extends StatelessWidget {
     super.key,
     required this.child,
     required this.onPressed,
+    this.onLongPressed,
     this.color = Colors.grey,
     this.padding = EdgeInsets.zero,
     this.buttonType = ButtonType.rectangle,
@@ -41,6 +45,7 @@ class ScalableButton extends StatelessWidget {
     return MaterialButton(
       color: createMaterialColor(color),
         onPressed: disabled ? null : onPressed,
+        onLongPress: disabled ? null : onLongPressed,
       animationDuration: Duration(milliseconds: 300),
       child: Center(
         child: child,

--- a/lib/src/widgets/scalable/scalable_button.dart
+++ b/lib/src/widgets/scalable/scalable_button.dart
@@ -9,7 +9,7 @@ class ScalableButton extends StatelessWidget {
   final bool disabled;
 
   /// Callback when the button is tapped.
-  final GestureTapCallback? onTap;
+  final GestureTapCallback? onPressed;
 
   /// Button display style (clipping). Defaults to [ButtonType.rectangle].
   /// [ButtonType.circle] will clip the button to a circle e.g. an iPhone keypad
@@ -28,7 +28,7 @@ class ScalableButton extends StatelessWidget {
   const ScalableButton({
     super.key,
     required this.child,
-    required this.onTap,
+    required this.onPressed,
     this.color = Colors.grey,
     this.padding = EdgeInsets.zero,
     this.buttonType = ButtonType.rectangle,
@@ -40,7 +40,7 @@ class ScalableButton extends StatelessWidget {
     // Use MaterialButton to get the Material ripple, splash and highlight colors including animations and gestures.
     return MaterialButton(
       color: createMaterialColor(color),
-      onPressed: disabled ? null : onTap,
+        onPressed: disabled ? null : onPressed,
       animationDuration: Duration(milliseconds: 300),
       child: Center(
         child: child,

--- a/lib/src/widgets/scalable/scaling_size.dart
+++ b/lib/src/widgets/scalable/scaling_size.dart
@@ -24,19 +24,19 @@ enum ScalingSize {
   double get scalar {
     switch (this) {
       case ScalingSize.smallest:
-        return 0.0003;
-      case ScalingSize.smaller:
-        return 0.0006;
-      case ScalingSize.small:
         return 0.001;
+      case ScalingSize.smaller:
+        return 0.002;
+      case ScalingSize.small:
+        return 0.004;
       case ScalingSize.medium:
-        return 0.003;
-      case ScalingSize.large:
         return 0.006;
+      case ScalingSize.large:
+        return 0.008;
       case ScalingSize.veryLarge:
-        return 0.01;
+        return 0.009;
       case ScalingSize.gigantic:
-        return 0.05;
+        return 0.01;
     }
   }
 }

--- a/lib/src/widgets/scalable/scaling_size.dart
+++ b/lib/src/widgets/scalable/scaling_size.dart
@@ -1,24 +1,24 @@
 /// Scaling Factor for the [ScalableButton]
 enum ScalingSize {
-  /// Scalar value: 0.0003
+  /// Scalar value: 0.001
   smallest,
 
-  /// Scalar value: 0.0006
+  /// Scalar value: 0.002
   smaller,
 
-  /// Scalar value: 0.001
+  /// Scalar value: 0.004
   small,
 
-  /// Scalar value: 0.003
+  /// Scalar value: 0.006
   medium,
 
-  /// Scalar value: 0.006
+  /// Scalar value: 0.008
   large,
 
-  /// Scalar value: 0.01
+  /// Scalar value: 0.009
   veryLarge,
 
-  /// Scalar value: 0.05
+  /// Scalar value: 0.01
   gigantic;
 
   double get scalar {


### PR DESCRIPTION
PR addresses UI inconsistencies with scaling, specifically text/icons get infinitely small and disappear easily.

- Added `minScalingSize` & `maxScalingSize` to address UI elements getting too small.
- Added dial, backspace button customization
- Fix circle buttons not clipping tap gesture