### PR TITLE
Add `initialText` property to autofill `PhoneTextInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [1.1.0] - 2023-00-23
+
 * Add custom keypad `keypad_generator`s with extensibility options.
 * Add `DialButton`with (future release) custom `keypadButtonBuilder` for specific usecases.
 * Refactor Flutter Dialpad with prebuilt UIs (iOS, metro theme styles).
@@ -24,7 +25,7 @@
 * Add scale clamping as a percentage of icon/text size for improved UI/UX, with defaults to [0.2, 1.0]
 * Added `hideBackspaceOnEmpty` to automatically hide backspace button when input is empty
 * Added `onTextChanged` to capture input text changed as displayed in the `PhoneTextInput`
-* Add `initialText` property to autofill `PhoneTextInput`
+* Add `initialText`, `withNumber` properties to autofill `PhoneTextInput`
 
 ## [1.0.5] - 2023-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add scale clamping as a percentage of icon/text size for improved UI/UX, with defaults to [0.2, 1.0]
 * Added `hideBackspaceOnEmpty` to automatically hide backspace button when input is empty
 * Added `onTextChanged` to capture input text changed as displayed in the `PhoneTextInput`
+* Add `initialText` property to autofill `PhoneTextInput`
 
 ## [1.0.5] - 2023-02-08
 

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -18,6 +18,9 @@ class DialPad extends StatefulWidget {
   /// Initial unformatted text to display in the text field e.g. 15551234567
   final String? initialText;
 
+  /// Updated number to display in the text field e.g. 15551234567
+  final String? withNumber;
+
   /// Callback when a key is pressed.
   final ValueSetter<String>? keyPressed;
 
@@ -146,6 +149,7 @@ class DialPad extends StatefulWidget {
   DialPad({
     this.makeCall,
     this.initialText,
+    this.withNumber,
     this.keyPressed,
     this.onTextChanged,
     this.hideDialButton = false,
@@ -253,7 +257,7 @@ class _DialPadState extends State<DialPad> {
   @override
   void initState() {
     super.initState();
-    _controller = MaskedTextController(text: widget.initialText, mask: widget.outputMask);
+    _controller = MaskedTextController(text: widget.initialText ?? widget.withNumber, mask: widget.outputMask);
     _value = _controller.text;
   }
 
@@ -332,6 +336,19 @@ class _DialPadState extends State<DialPad> {
       minScalingSize: widget.minScalingSize,
       maxScalingSize: widget.maxScalingSize,
     );
+  }
+
+  @override
+  void didUpdateWidget(DialPad oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // if the withNumber property has changed, update the text field
+    if (widget.withNumber != null && widget.withNumber != oldWidget.withNumber) {
+      // update text field
+      _controller.updateText(widget.withNumber ?? "");
+      // update value with masked number
+      _value = _controller.text;
+    }
   }
 
   @override

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -15,6 +15,9 @@ class DialPad extends StatefulWidget {
   /// Callback when the dial button is pressed.
   final ValueSetter<String>? makeCall;
 
+  /// Initial unformatted text to display in the text field e.g. 15551234567
+  final String? initialText;
+
   /// Callback when a key is pressed.
   final ValueSetter<String>? keyPressed;
 
@@ -142,6 +145,7 @@ class DialPad extends StatefulWidget {
 
   DialPad({
     this.makeCall,
+    this.initialText,
     this.keyPressed,
     this.onTextChanged,
     this.hideDialButton = false,
@@ -249,7 +253,8 @@ class _DialPadState extends State<DialPad> {
   @override
   void initState() {
     super.initState();
-    _controller = MaskedTextController(mask: widget.outputMask);
+    _controller = MaskedTextController(text: widget.initialText, mask: widget.outputMask);
+    _value = _controller.text;
   }
 
   /// Handles text field content change, notifies [onTextChanged] callback


### PR DESCRIPTION
Describes a use-case in which data is sent to a UI to pre-fill the dialer screen. 