### PR TITLE
Fix: missing key pressed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.1] - 2023-01-12
+
+* Fix missing `keyPressed` event for individual keys pressed on the keypad.
+
 ## [1.1.0] - 2023-00-23
 
 * Add custom keypad `keypad_generator`s with extensibility options.

--- a/lib/flutter_dialpad.dart
+++ b/lib/flutter_dialpad.dart
@@ -274,6 +274,7 @@ class _DialPadState extends State<DialPad> {
   /// Handles keypad button press, this includes numbers and [DialActionKey] except [DialActionKey.backspace]
   void _onKeyPressed(String? value) {
     if (value != null) {
+      widget.keyPressed?.call(value);
       setState(() {
         _value += value;
         _controller.updateText(_value);


### PR DESCRIPTION
Add missing key pressed to `_onKeyPressed` event for sending individual digits. 